### PR TITLE
Fix crash using save_sprite_changes string

### DIFF
--- a/Korean/aseprite-language-ko/ko.ini
+++ b/Korean/aseprite-language-ko/ko.ini
@@ -132,7 +132,7 @@ restore_all_shortcuts = <<<END
 END
 save_sprite_changes = <<<END
  경고
-<<{1} 이전 {"0"} 스프라이트에
+<<{1} 이전 "{0}" 스프라이트에
 <<변경된 사항을 저장하시겠습니까?
 ||&저장||저장하지 않음||&취소
 END


### PR DESCRIPTION
The quotes (") must be outside the {...} chars. We have received a crash report when using this string (we'll try to make the program more robust to invalid format strings anyway).