### PR TITLE
Add missing font size in <font> elements (fix #10)

### DIFF
--- a/Korean/aseprite-theme-ko/dark/theme.xml
+++ b/Korean/aseprite-theme-ko/dark/theme.xml
@@ -11,8 +11,8 @@
         <font name="Korean" type="truetype" antialias="false" file="./AsepriteKorean.ttf">
         <fallback font="Unicode Korean" size="10" />
         </font>
-        <font id="default" font="Korean" />
-        <font id="mini" font="Korean" />
+        <font id="default" font="Korean" size="12" />
+        <font id="mini" font="Korean" size="12" />
     </fonts>
     <dimensions>
         <dim id="scrollbar_size" value="12" />

--- a/Korean/aseprite-theme-ko/theme.xml
+++ b/Korean/aseprite-theme-ko/theme.xml
@@ -10,8 +10,8 @@
         <font name="Korean" type="truetype" antialias="false" file="./AsepriteKorean.ttf">
         <fallback font="Unicode Korean" size="10" />
         </font>
-        <font id="default" font="Korean" />
-        <font id="mini" font="Korean" />
+        <font id="default" font="Korean" size="12" />
+        <font id="mini" font="Korean" size="12" />
     </fonts>
     <dimensions>
         <dim id="scrollbar_size" value="12" />


### PR DESCRIPTION
This fixes and issue for Aseprite v1.3.14.2 where the font size is expected in <font> elements with id:

  https://github.com/aseprite/aseprite/issues/5229

This issue will be fixed in Aseprite v1.3.14.3 but it'd be nice to include the font size anyway.